### PR TITLE
Fix app loading by switching to JSONP instead of broken CORS proxies

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,58 +39,79 @@
       }
     };
 
-    const CORS_PROXIES = [
-      {
-        name: 'allorigins',
-        buildUrl: (url) => `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`,
-        parseResponse: async (r) => JSON.parse((await r.json()).contents)
-      },
-      {
-        name: 'corsproxy.io',
-        buildUrl: (url) => `https://corsproxy.io/?${encodeURIComponent(url)}`,
-        parseResponse: async (r) => await r.json()
-      },
-    ];
+    function fetchJsonp(url, timeoutMs = 8000) {
+      return new Promise((resolve, reject) => {
+        const cbName = 'jsonpCb_' + Date.now() + '_' + Math.round(Math.random() * 100000);
+        const script = document.createElement('script');
+        let settled = false;
 
-    const FETCH_TIMEOUT_MS = 6000;
+        function cleanup() {
+          if (script.parentNode) script.parentNode.removeChild(script);
+          delete window[cbName];
+        }
 
-    function fetchWithTimeout(url, timeoutMs) {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-      return fetch(url, { signal: controller.signal })
-        .finally(() => clearTimeout(timeoutId));
+        const timer = setTimeout(() => {
+          if (!settled) {
+            settled = true;
+            cleanup();
+            reject(new Error('JSONP timeout'));
+          }
+        }, timeoutMs);
+
+        window[cbName] = (data) => {
+          if (!settled) {
+            settled = true;
+            clearTimeout(timer);
+            cleanup();
+            resolve(data);
+          }
+        };
+
+        script.src = url + (url.includes('?') ? '&' : '?') + 'callback=' + cbName;
+        script.onerror = () => {
+          if (!settled) {
+            settled = true;
+            clearTimeout(timer);
+            cleanup();
+            reject(new Error('JSONP script load failed'));
+          }
+        };
+
+        document.head.appendChild(script);
+      });
+    }
+
+    async function fetchViaProxy(appId) {
+      const proxy = 'https://api.allorigins.win/get?url=';
+      const url = `https://itunes.apple.com/lookup?id=${appId}`;
+      const response = await fetch(`${proxy}${encodeURIComponent(url)}`);
+      if (!response.ok) throw new Error(`Proxy HTTP ${response.status}`);
+      const proxyData = await response.json();
+      return JSON.parse(proxyData.contents);
     }
 
     async function fetchAppData(appId) {
-      const url = `https://itunes.apple.com/lookup?id=${appId}`;
-      const errors = [];
-
-      for (const proxy of CORS_PROXIES) {
-        try {
-          const proxyUrl = proxy.buildUrl(url);
-          const response = await fetchWithTimeout(proxyUrl, FETCH_TIMEOUT_MS);
-
-          if (!response.ok) {
-            throw new Error(`HTTP ${response.status} from ${proxy.name}`);
-          }
-
-          const data = await proxy.parseResponse(response);
-
-          if (!data.results || data.results.length === 0) {
-            throw new Error(`No results from ${proxy.name} for appId: ${appId}`);
-          }
-
+      // Primary: JSONP (bypasses CORS entirely, no proxy needed)
+      try {
+        const data = await fetchJsonp(`https://itunes.apple.com/lookup?id=${appId}`);
+        if (data.results && data.results.length > 0) {
           return data.results[0];
-        } catch (error) {
-          const errorMsg = error.name === 'AbortError'
-            ? `Timeout (${FETCH_TIMEOUT_MS}ms) via ${proxy.name}`
-            : `${proxy.name}: ${error.message}`;
-          errors.push(errorMsg);
-          console.warn(`Proxy ${proxy.name} failed for appId ${appId}:`, errorMsg);
         }
+      } catch (err) {
+        console.warn(`JSONP failed for appId ${appId}:`, err.message);
       }
 
-      console.error(`All proxies failed for appId ${appId}:`, errors);
+      // Fallback: allorigins proxy
+      try {
+        const data = await fetchViaProxy(appId);
+        if (data.results && data.results.length > 0) {
+          return data.results[0];
+        }
+      } catch (err) {
+        console.warn(`Proxy fallback failed for appId ${appId}:`, err.message);
+      }
+
+      console.error(`All methods failed for appId ${appId}`);
       return undefined;
     }
 


### PR DESCRIPTION
The corsproxy.io proxy started returning 403 (requires paid plan), causing all apps to fail loading. Now uses JSONP which calls the iTunes API directly by injecting script tags — no CORS proxy needed. Keeps allorigins as fallback.